### PR TITLE
Deprecate image maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Schema Registry provides a RESTful interface for storing and retrieving [Avro](https://avro.apache.org) schemas. It is a part of the [Confluent Platform](https://confluent.io/product/).
 
-This image is currently maintained by the Research Management Systems project at the [University of Calgary](http://www.ucalgary.ca/).
+**NOTE: This image is no longer maintained. See [confluentinc/cp-schema-registry](https://hub.docker.com/r/confluentinc/cp-schema-registry/) for Schema Registry images.**


### PR DESCRIPTION
The RMS project will no longer maintain this image. See the images
under confluentinc for replacements.